### PR TITLE
Add Claude Code integration snippet to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,22 @@ You can run with docker using:
 ```bash
 docker run --rm -i timsmart/effect-mcp
 ```
+
+## Claude Code Integration
+
+To use this MCP server with Claude Code, run the following command:
+
+```bash
+claude mcp add-json effect-docs '{ 
+  "command": "docker",
+  "args": [
+    "run",
+    "--rm",
+    "-i",
+    "timsmart/effect-mcp"
+  ],
+  "env": {}
+}' -s user
+```
+
+This configuration separates the command and arguments to avoid Docker spawn errors that can occur when using a single command string.


### PR DESCRIPTION
## Summary
- Added a Claude Code integration section to the README
- Included the proper `claude mcp add-json` command with separated args to avoid Docker spawn errors
- Addresses issue #1 regarding Docker ENOENT errors

## Context
This PR adds documentation for Claude Code users based on the solution discussed in issue #1. The key change is using the JSON configuration format with separated `command` and `args` parameters instead of a single command string.

🤖 Generated with [Claude Code](https://claude.ai/code)