### PR TITLE
fixed trailing comma issue with the claude code command

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ claude mcp add-json effect-docs '{
   "command": "npx",
   "args": [
     "-y",
-    "effect-mcp",
+    "effect-mcp"
   ],
   "env": {}
 }' -s user


### PR DESCRIPTION
fixed a trailing comma issue with the claude code command in the [README](https://github.com/gabedemesa/effect-mcp/blob/476c4a47316d28e4a283d3bc6506c6368646ed59/README.md?plain=1#L30). 

when I copied and pasted the claude code command from the README, I ran into an issue. This PR fixes that issue.

## Issue
```zsh
gdemesa@MAC-GDEMESA effect-mcp % claude mcp add-json effect-docs '{
  "command": "npx",
  "args": [
    "-y",
    "effect-mcp",
  ],
  "env": {}
}' -s user
Invalid JSON # output
```

## After fix
```zsh
gdemesa@MAC-GDEMESA effect-mcp % claude mcp add-json effect-docs '{
  "command": "npx",
  "args": [
    "-y",
    "effect-mcp" 
  ],
  "env": {}
}' -s user
Added stdio MCP server effect-docs to user config # output
```
