### PR TITLE
Update README with cursor json instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,16 @@ Or use npx:
 npx -y effect-mcp
 ```
 
+## Cursor
+To use this MCP server with Cursor, please add the following to your cursor `mcp.json`:
+
+```json
+"effect-docs": {
+  "command": "npx",
+  "args": ["-y", "effect-mcp@latest"]
+}
+```
+
 ## Claude Code Integration
 
 To use this MCP server with Claude Code, run the following command:


### PR DESCRIPTION
I noticed we lost the "Add to Cursor" button from https://github.com/tim-smart/effect-mcp/commit/010a34de82babae53f731d7c73d0871129313831, so I am simply just adding these instructions in lieu of the button.

I sent my coworker to this repo so she could use this MCP server in Cursor, however I saw that we lost the instructions to add to Cursor. So I had to come up with this on the fly to help her add this to her Cursor MCP settings. Hopefully this helps others in the future as well. 